### PR TITLE
Add driver module

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.1'
+services:
+  dev-db:
+    image: postgis/postgis
+    restart: always
+    ports:
+      - 9000:5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: 1234
+      POSTGRES_DB: taxi24
+    networks:
+      - taxi24-api
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 9001:8080
+    networks:
+      - taxi24-api
+networks:
+  taxi24-api:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "postgres": "^3.4.3",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1"
       },
@@ -6907,6 +6908,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postgres": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.3.tgz",
+      "integrity": "sha512-iHJn4+M9vbTdHSdDzNkC0crHq+1CUdFhx+YqCE+SqWxPjm+Zu63jq7yZborOBF64c8pc58O5uMudyL1FQcHacA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "postgres": "^3.4.3",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"
   },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { DriverModule } from './driver/driver.module';
 
 @Module({
-  imports: [],
+  imports: [DriverModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/coordinate.ts
+++ b/src/coordinate.ts
@@ -1,0 +1,6 @@
+type Coordinate = {
+  latitude: number;
+  longitude: number;
+};
+
+export default Coordinate;

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,5 @@
+import * as postgres from 'postgres';
+
+const sql = postgres('postgres://postgres:1234@127.0.0.1:9000/taxi24');
+
+export default sql;

--- a/src/driver/driver.controller.spec.ts
+++ b/src/driver/driver.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DriverController } from './driver.controller';
+
+describe('DriverController', () => {
+  let controller: DriverController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DriverController],
+    }).compile();
+
+    controller = module.get<DriverController>(DriverController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/driver/driver.controller.ts
+++ b/src/driver/driver.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import Driver from './driver';
+import { DriverService } from './driver.service';
+import Coordinate from 'src/coordinate';
+
+@Controller('drivers')
+export class DriverController {
+  constructor(private driverService: DriverService) {}
+
+  @Get()
+  async findAll(): Promise<Driver[]> {
+    const drivers = await this.driverService.findAll();
+
+    return drivers;
+  }
+
+  @Get('available')
+  async findAvailable(): Promise<Driver[]> {
+    const drivers = await this.driverService.findAvailable();
+
+    return drivers;
+  }
+
+  @Get('in-radius/:latitude/:longitude')
+  async findInRadius(@Param() params: Coordinate): Promise<Driver[]> {
+    const drivers = await this.driverService.findInRadius(params);
+
+    return drivers;
+  }
+
+  @Get(':id')
+  async find(@Param() params: { id: number }): Promise<Driver> {
+    const driver = await this.driverService.find(params.id);
+
+    return driver;
+  }
+}

--- a/src/driver/driver.module.ts
+++ b/src/driver/driver.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { DriverController } from './driver.controller';
+import { DriverService } from './driver.service';
+
+@Module({
+  controllers: [DriverController],
+  providers: [DriverService],
+})
+export class DriverModule {}

--- a/src/driver/driver.service.spec.ts
+++ b/src/driver/driver.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DriverService } from './driver.service';
+
+describe('DriverService', () => {
+  let service: DriverService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DriverService],
+    }).compile();
+
+    service = module.get<DriverService>(DriverService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/driver/driver.service.ts
+++ b/src/driver/driver.service.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@nestjs/common';
+import sql from '../db';
+import Driver from './driver';
+import Coordinate from 'src/coordinate';
+
+@Injectable()
+export class DriverService {
+  async findAll(): Promise<Driver[]> {
+    const drivers = await sql<Driver[]>`
+      SELECT id, name, profile_picture
+      FROM drivers
+    `;
+
+    return drivers;
+  }
+
+  async findAvailable(): Promise<Driver[]> {
+    const drivers = await sql<Driver[]>`
+      SELECT
+      id,
+      name,
+      profile_picture
+      FROM drivers
+      WHERE id IN(
+        SELECT driver_id
+        FROM drivers_location
+        WHERE
+        is_available = 'true'
+      )`;
+
+    return drivers;
+  }
+
+  async findInRadius(coordinate: Coordinate): Promise<Driver[]> {
+    const drivers = await sql<Driver[]>`
+      SELECT
+      id,
+      name,
+      profile_picture
+      FROM drivers
+      WHERE id IN(
+        SELECT driver_id
+        FROM drivers_location
+        WHERE
+        is_available = 'true'
+        AND
+        (ST_DistanceSphere(
+          ST_MakePoint(drivers_location.latitude::float, drivers_location.longitude::float),
+          ST_MakePoint(${coordinate.latitude}, ${coordinate.longitude})
+        ) / 1000) <= 3
+      )`;
+
+    return drivers;
+  }
+
+  async find(id: number): Promise<Driver> {
+    const driver = await sql<Driver[]>`
+      SELECT id, name, is_available
+      FROM drivers
+      WHERE id = ${id}
+  `;
+
+    return driver[0];
+  }
+}

--- a/src/driver/driver.ts
+++ b/src/driver/driver.ts
@@ -1,0 +1,7 @@
+type Driver = {
+  id: number;
+  name: string;
+  profile_picture: string;
+};
+
+export default Driver;


### PR DESCRIPTION
This is a first iteration of the driver module, it adds the following endpoints:

`GET /drivers`: returns all the drivers
`GET /drivers/available`: returns only the drivers that are available at the moment
`GET /drivers/in-radius/:latitude/:longitude`: returns the drivers available in a 3km radius
`GET /drivers/:id`: returns the driver with the specified id

Features like validation, security, and testing are missing at the moment and will be added in a next iteration.