### PR TITLE
Add passenger module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DriverModule } from './driver/driver.module';
+import { PassengerModule } from './passenger/passenger.module';
 
 @Module({
-  imports: [DriverModule],
+  imports: [DriverModule, PassengerModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/passenger/passenger.controller.spec.ts
+++ b/src/passenger/passenger.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PassengerController } from './passenger.controller';
+
+describe('PassengerController', () => {
+  let controller: PassengerController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PassengerController],
+    }).compile();
+
+    controller = module.get<PassengerController>(PassengerController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/passenger/passenger.controller.ts
+++ b/src/passenger/passenger.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import Driver from 'src/driver/driver';
+import { PassengerService } from './passenger.service';
+import Passenger from './passenger';
+
+@Controller('passengers')
+export class PassengerController {
+  constructor(private passengerService: PassengerService) {}
+
+  @Get()
+  async findAll(): Promise<Passenger[]> {
+    const passengers = await this.passengerService.findAll();
+
+    return passengers;
+  }
+
+  @Get(':id')
+  async find(@Param() params: { id: number }): Promise<Passenger> {
+    const passenger = await this.passengerService.find(params.id);
+
+    return passenger;
+  }
+
+  @Get(':id/near-drivers')
+  async findNearDrivers(@Param() params: { id: number }): Promise<Driver[]> {
+    const drivers = await this.passengerService.findNearDriversByPassengerId(
+      params.id,
+    );
+
+    return drivers;
+  }
+}

--- a/src/passenger/passenger.module.ts
+++ b/src/passenger/passenger.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PassengerController } from './passenger.controller';
+import { PassengerService } from './passenger.service';
+
+@Module({
+  controllers: [PassengerController],
+  providers: [PassengerService],
+})
+export class PassengerModule {}

--- a/src/passenger/passenger.service.spec.ts
+++ b/src/passenger/passenger.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PassengerService } from './passenger.service';
+
+describe('PassengerService', () => {
+  let service: PassengerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PassengerService],
+    }).compile();
+
+    service = module.get<PassengerService>(PassengerService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/passenger/passenger.service.ts
+++ b/src/passenger/passenger.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import Passenger from './passenger';
+import sql from 'src/db';
+import Driver from 'src/driver/driver';
+
+@Injectable()
+export class PassengerService {
+  async findAll(): Promise<Passenger[]> {
+    const passengers = await sql<Passenger[]>`
+      SELECT id, name, profile_picture
+      FROM passengers
+    `;
+
+    return passengers;
+  }
+
+  async find(id: number): Promise<Passenger> {
+    const passenger = await sql<Passenger[]>`
+      SELECT id, name, profile_picture
+      FROM passengers
+      WHERE id = ${id}
+  `;
+
+    return passenger[0];
+  }
+
+  async findNearDriversByPassengerId(id: number): Promise<Driver[]> {
+    const drivers = await sql<Driver[]>`
+      SELECT
+      drivers.id,
+      drivers.name,
+      drivers.profile_picture
+      FROM drivers
+      INNER JOIN drivers_location
+      ON drivers.id = drivers_location.driver_id
+      WHERE drivers_location.is_available = 'true'
+      ORDER BY
+      (ST_DistanceSphere(
+        ST_MakePoint(drivers_location.latitude::float, drivers_location.longitude::float),
+        ST_MakePoint(
+          (SELECT longitude FROM passengers_location WHERE passenger_id = ${id} LIMIT 1)::float,
+          (SELECT latitude FROM passengers_location WHERE passenger_id = ${id} LIMIT 1)::float
+        )
+      ) / 1000)
+      LIMIT 3`;
+
+    return drivers;
+  }
+}

--- a/src/passenger/passenger.ts
+++ b/src/passenger/passenger.ts
@@ -1,0 +1,7 @@
+type Passenger = {
+  id: number;
+  name: string;
+  profile_picture: string;
+};
+
+export default Passenger;


### PR DESCRIPTION
This is a first iteration of the passenger module, it adds the following endpoints:

`GET /passengers`: returns all the passengers
`GET /passengers/:id`: returns the passenger with the specified id
`GET /passengers/:id/near-drivers`: returns the three drivers closest to the passenger

Features like validation, security, and testing are missing at the moment and will be added in a next iteration.