### PR TITLE
Fix find driver query

### DIFF
--- a/src/driver/driver.service.ts
+++ b/src/driver/driver.service.ts
@@ -55,7 +55,7 @@ export class DriverService {
 
   async find(id: number): Promise<Driver> {
     const driver = await sql<Driver[]>`
-      SELECT id, name, is_available
+      SELECT id, name, profile_picture
       FROM drivers
       WHERE id = ${id}
   `;


### PR DESCRIPTION
The query was assuming an out of date table schema, thus making the profile_picture not show up in the JSON response, this should fix it.