### PR TITLE
Remove Swagger plugin

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,12 +3,6 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true,
-    "plugins": [{
-      "name": "@nestjs/swagger",
-      "options": {
-        "introspectComments": true
-      }
-    }]
+    "deleteOutDir": true
   }
 }

--- a/src/driver/entities/driver.entity.ts
+++ b/src/driver/entities/driver.entity.ts
@@ -1,26 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 import { IsInt, IsUrl, Min } from 'class-validator';
 
 export class Driver {
-  /**
-   * The identifier of the resource
-   */
   @IsInt()
   @Min(1)
+  @ApiProperty({ description: 'The identifier of the resource' })
   id: number;
 
-  /**
-   * The full name of the passenger
-   * @example John Doe
-   */
+  @ApiProperty({
+    description: 'The full name of the driver',
+    example: 'John Doe',
+  })
   name: string;
 
-  /**
-   * A URL pointing to an image file
-   * @example https://example.com/picture.jpeg
-   */
   @IsUrl()
   @Expose({ name: 'profilePicture' })
+  @ApiProperty({
+    description: 'A URL pointing to an image file',
+    example: 'https://example.com/picture.jpeg',
+    name: 'profilePicture',
+  })
   profile_picture?: string;
 
   constructor(partial: Partial<Driver>) {

--- a/src/passenger/entities/passenger.entity.ts
+++ b/src/passenger/entities/passenger.entity.ts
@@ -1,26 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 import { IsInt, IsUrl, Min } from 'class-validator';
 
 export class Passenger {
-  /**
-   * The identifier of the resource
-   */
   @IsInt()
   @Min(1)
+  @ApiProperty({ description: 'The identifier of the resource' })
   id: number;
 
-  /**
-   * The full name of the passenger
-   * @example John Doe
-   */
+  @ApiProperty({
+    description: 'The full name of the passenger',
+    example: 'John Doe',
+  })
   name: string;
 
-  /**
-   * A URL pointing to an image file
-   * @example https://example.com/picture.jpeg
-   */
   @IsUrl()
   @Expose({ name: 'profilePicture' })
+  @ApiProperty({
+    description: 'A URL pointing to an image file',
+    example: 'https://example.com/picture.jpeg',
+    name: 'profilePicture',
+  })
   profile_picture?: string;
 
   constructor(partial: Partial<Passenger>) {

--- a/src/ride/entities/ride.entity.ts
+++ b/src/ride/entities/ride.entity.ts
@@ -1,58 +1,65 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 import { IsInt, Min } from 'class-validator';
 
 export class Ride {
-  /**
-   * The identifier of the resource
-   */
   @IsInt()
   @Min(1)
+  @ApiProperty({ description: 'The identifier of the resource' })
   id: number;
 
-  /**
-   * A valid latitude represented as a floating point number
-   * @example 18.4636960171801
-   */
   @Expose({ name: 'originLatitude' })
+  @ApiProperty({
+    description: 'A valid latitude represented as a floating point number',
+    example: '18.4636960171801',
+    name: 'originLatitude',
+  })
   origin_latitude: string;
 
-  /**
-   * A valid longitude represented as a floating point number
-   * @example -69.93474882920843
-   */
   @Expose({ name: 'originLongitude' })
+  @ApiProperty({
+    description: 'A valid longitude represented as a floating point number',
+    example: '-69.93474882920843',
+    name: 'originLongitude',
+  })
   origin_longitude: string;
 
-  /**
-   * A valid latitude represented as a floating point number
-   * @example 18.47553627458603
-   */
   @Expose({ name: 'destinationLatitude' })
+  @ApiProperty({
+    description: 'A valid latitude represented as a floating point number',
+    example: '18.47553627458603',
+    name: 'destinationLatitude',
+  })
   destination_latitude: string;
 
-  /**
-   * A valid longitude represented as a floating point number
-   * @example -69.94349904538785
-   */
   @Expose({ name: 'destinationLongitude' })
+  @ApiProperty({
+    description: 'A valid longitude represented as a floating point number',
+    example: '-69.94349904538785',
+    name: 'destinationLongitude',
+  })
   destination_longitude: string;
 
-  /**
-   * A boolean representing if the ride has been completed
-   */
   @Expose({ name: 'isCompleted' })
+  @ApiProperty({
+    description: 'A boolean representing if the ride has been completed',
+    name: 'isCompleted',
+  })
   is_completed: boolean;
 
-  /**
-   * The identifier of the driver associated with this resource
-   */
   @Expose({ name: 'driverId' })
+  @ApiProperty({
+    description: ' The identifier of the driver associated with this resource',
+    name: 'driverId',
+  })
   driver_id: number;
 
-  /**
-   * The identifier of the passenger associated with this resource
-   */
   @Expose({ name: 'passengerId' })
+  @ApiProperty({
+    description:
+      ' The identifier of the passenger associated with this resource',
+    name: 'passengerId',
+  })
   passenger_id: number;
 
   constructor(partial: Partial<Ride>) {


### PR DESCRIPTION
This PR removes the use of the `@nestjs/swagger` plugin and revert back to using the `ApiProperty` decorator for entities. This goes more inline with the use of serialization.