### PR TITLE
Improve endpoints signature

### DIFF
--- a/src/coordinate.ts
+++ b/src/coordinate.ts
@@ -1,6 +1,0 @@
-type Coordinate = {
-  latitude: number;
-  longitude: number;
-};
-
-export default Coordinate;

--- a/src/driver/driver.service.ts
+++ b/src/driver/driver.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import sql from '../db';
 import { Driver } from './entities/driver.entity';
-import Coordinate from 'src/coordinate';
 
 @Injectable()
 export class DriverService {
@@ -29,7 +28,7 @@ export class DriverService {
     return drivers.map((driver) => new Driver(driver));
   }
 
-  async findInRadius(coordinate: Coordinate): Promise<Driver[]> {
+  async findInRadius(latitude: string, longitude: string): Promise<Driver[]> {
     const drivers = await sql<Driver[]>`
       SELECT
         "d"."id",
@@ -42,7 +41,7 @@ export class DriverService {
       AND
       (ST_DistanceSphere(
         ST_MakePoint("dl"."latitude"::float, "dl"."longitude"::float),
-        ST_MakePoint(${coordinate.latitude}, ${coordinate.longitude})
+        ST_MakePoint(${latitude}, ${longitude})
       ) / 1000) <= 3
     `;
 

--- a/src/passenger/passenger.controller.ts
+++ b/src/passenger/passenger.controller.ts
@@ -1,5 +1,4 @@
 import {
-  ApiParam,
   ApiOperation,
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -30,16 +29,11 @@ export class PassengerController {
     type: Passenger,
   })
   async findAll(): Promise<Passenger[]> {
-    const passengers = await this.passengerService.findAll();
-
-    return passengers;
+    return this.passengerService.findAll();
   }
 
   @Get(':id')
-  @ApiParam({ name: 'id', type: 'integer' })
-  @ApiOperation({
-    summary: 'Get the passenger with the specified id',
-  })
+  @ApiOperation({ summary: 'Get the passenger with the specified id' })
   @ApiOkResponse({
     description: 'Request has been successful.',
     type: Passenger,
@@ -47,14 +41,11 @@ export class PassengerController {
   @ApiNotFoundResponse({
     description: 'We could not find a passenger with the specified id.',
   })
-  async find(@Param() params: { id: number }): Promise<Passenger> {
-    const passenger = await this.passengerService.find(params.id);
-
-    return passenger;
+  async find(@Param('id') id: number): Promise<Passenger> {
+    return this.passengerService.find(id);
   }
 
   @Get(':id/near-drivers')
-  @ApiParam({ name: 'id', type: 'integer' })
   @ApiOperation({
     summary: "Get the three drivers nearest to the passenger's location",
   })
@@ -66,11 +57,7 @@ export class PassengerController {
   @ApiNotFoundResponse({
     description: 'We could not find a passenger with the specified id.',
   })
-  async findNearDrivers(@Param() params: { id: number }): Promise<Driver[]> {
-    const drivers = await this.passengerService.findNearDriversByPassengerId(
-      params.id,
-    );
-
-    return drivers;
+  async findNearDrivers(@Param('id') id: number): Promise<Driver[]> {
+    return this.passengerService.findNearDriversByPassengerId(id);
   }
 }

--- a/src/ride/ride.controller.ts
+++ b/src/ride/ride.controller.ts
@@ -1,5 +1,4 @@
 import {
-  ApiParam,
   ApiOperation,
   ApiBadRequestResponse,
   ApiCreatedResponse,
@@ -38,15 +37,10 @@ export class RideController {
   })
   @ApiBadRequestResponse({ description: 'Request is invalid.' })
   async create(@Body() createRideDTO: CreateRideDTO): Promise<Ride> {
-    const ride = await this.rideService.create(createRideDTO);
-
-    console.log(ride);
-
-    return ride;
+    return await this.rideService.create(createRideDTO);
   }
 
   @Put(':id')
-  @ApiParam({ name: 'id', type: 'integer' })
   @ApiOperation({
     requestBody: { $ref: 'UpdateRideDTO' },
     summary: 'Update a ride',
@@ -57,12 +51,10 @@ export class RideController {
   })
   @ApiBadRequestResponse({ description: 'Request is invalid.' })
   async update(
-    @Param() params: { id: number },
+    @Param('id') id: number,
     @Body() updateRideDTO: UpdateRideDTO,
-  ) {
-    const ride = await this.rideService.update(params.id, updateRideDTO);
-
-    return ride;
+  ): Promise<Ride> {
+    return this.rideService.update(id, updateRideDTO);
   }
 
   @Get('active')
@@ -76,8 +68,6 @@ export class RideController {
     type: Ride,
   })
   async findActive(): Promise<Ride[]> {
-    const rides = await this.rideService.findActive();
-
-    return rides;
+    return await this.rideService.findActive();
   }
 }


### PR DESCRIPTION
This PR make minor improvements to the endpoints signature, particularly going from `GET /drivers/available` to `GET /drivers?available=true` and from `GET /drivers/{latitude}/{longitude}` to `GET /drivers/near-by?latitude=&longitude=`. Improvements to the code were made to make it more concise.