### PR TITLE
Fix /rides/active endpoint signature

### DIFF
--- a/src/ride/ride.controller.ts
+++ b/src/ride/ride.controller.ts
@@ -13,6 +13,7 @@ import {
   Param,
   Post,
   Put,
+  Query,
   UseInterceptors,
 } from '@nestjs/common';
 import { CreateRideDTO } from './dto/create-ride.dto';
@@ -57,17 +58,20 @@ export class RideController {
     return this.rideService.update(id, updateRideDTO);
   }
 
-  @Get('active')
-  @ApiOperation({
-    requestBody: { $ref: 'UpdateRideDTO' },
-    summary: 'Get the all the active rides',
-  })
+  @Get()
+  @ApiOperation({ summary: 'Get the the active rides' })
   @ApiOkResponse({
     description: 'Request has been successful.',
     isArray: true,
     type: Ride,
   })
-  async findActive(): Promise<Ride[]> {
-    return await this.rideService.findActive();
+  async findActive(
+    @Query() query: { active?: 'true' | 'false' },
+  ): Promise<Ride[]> {
+    if (query.active === 'true') {
+      return await this.rideService.findActive();
+    }
+
+    return await this.rideService.findAll();
   }
 }

--- a/src/ride/ride.service.ts
+++ b/src/ride/ride.service.ts
@@ -88,4 +88,21 @@ export class RideService {
 
     return rides.map((ride) => new Ride(ride));
   }
+
+  async findAll(): Promise<Ride[]> {
+    const rides = await this.databaseService.connection<Ride[]>`
+      SELECT
+        "id",
+        "origin_latitude",
+        "origin_longitude",
+        "destination_latitude",
+        "destination_longitude",
+        "driver_id",
+        "passenger_id",
+        "is_completed"
+      FROM "rides"
+    `;
+
+    return rides.map((ride) => new Ride(ride));
+  }
 }


### PR DESCRIPTION
This PR changes the endpoint `GET /rides/active` to `GET /rides?active=true` to make it complaint with the REST specification. It also adds the possibility to get every single ride by calling `GET /rides`.