### PR TITLE
Add GET /passengers/:id/invoices endpoint

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,18 +2,18 @@ import { ConfigModule } from '@nestjs/config';
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { DatabaseModule } from './database/database.module';
 import { DriverModule } from './driver/driver.module';
 import { PassengerModule } from './passenger/passenger.module';
 import { RideModule } from './ride/ride.module';
-import { DatabaseModule } from './database/database.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot(),
+    DatabaseModule,
     DriverModule,
     PassengerModule,
     RideModule,
-    DatabaseModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/driver/entities/driver.entity.ts
+++ b/src/driver/entities/driver.entity.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
-import { IsInt, IsUrl, Min } from 'class-validator';
+import { IsInt, IsNotEmpty, IsUrl, Min } from 'class-validator';
 
 export class Driver {
   @IsInt()
@@ -8,6 +8,7 @@ export class Driver {
   @ApiProperty({ description: 'The identifier of the resource' })
   id: number;
 
+  @IsNotEmpty()
   @ApiProperty({
     description: 'The full name of the driver',
     example: 'John Doe',

--- a/src/invoice/entities/invoice.entity.ts
+++ b/src/invoice/entities/invoice.entity.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsDate, IsDecimal, IsInt, MaxLength, Min } from 'class-validator';
+
+export class Invoice {
+  @IsInt()
+  @Min(1)
+  @ApiProperty({ description: 'The identifier of the resource' })
+  id: number;
+
+  @IsDecimal({ decimal_digits: '2', force_decimal: true })
+  @MaxLength(8)
+  @Min(1)
+  @ApiProperty({
+    description:
+      'A floating point number with a max of five numbers before the decimal point, and two after it',
+    example: 6.01,
+  })
+  price: number;
+
+  @IsInt()
+  @Min(1)
+  @Expose({ name: 'rideId' })
+  @ApiProperty({
+    description: 'The identifier of the ride associated with this resource',
+    name: 'rideId',
+  })
+  ride_id: number;
+
+  @IsDate()
+  @Expose({ name: 'createdAt' })
+  @ApiProperty({
+    description: 'A timestamp representing when the resource was created',
+    name: 'createdAt',
+  })
+  created_at: Date;
+
+  constructor(partial: Partial<Invoice>) {
+    Object.assign(this, partial);
+  }
+}

--- a/src/passenger/passenger.controller.ts
+++ b/src/passenger/passenger.controller.ts
@@ -14,6 +14,7 @@ import {
 import { Driver } from '../driver/entities/driver.entity';
 import { Passenger } from './entities/passenger.entity';
 import { PassengerService } from './passenger.service';
+import { Invoice } from 'src/invoice/entities/invoice.entity';
 
 @ApiTags('passengers')
 @Controller('passengers')
@@ -59,5 +60,16 @@ export class PassengerController {
   })
   async findNearDrivers(@Param('id') id: number): Promise<Driver[]> {
     return this.passengerService.findNearDriversByPassengerId(id);
+  }
+
+  @Get(':id/invoices')
+  @ApiOperation({ summary: 'Get all invoices belonging to a given passenger.' })
+  @ApiOkResponse({
+    description: 'Request has been successful.',
+    isArray: true,
+    type: Invoice,
+  })
+  async findInvoicesByPassengerId(@Param('id') id: number): Promise<Invoice[]> {
+    return this.passengerService.findInvoicesByPassengerId(id);
   }
 }

--- a/src/passenger/passenger.service.ts
+++ b/src/passenger/passenger.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { DatabaseService } from '../database/database.service';
 import { Driver } from '../driver/entities/driver.entity';
 import { Passenger } from './entities/passenger.entity';
+import { Invoice } from 'src/invoice/entities/invoice.entity';
 
 @Injectable()
 export class PassengerService {
@@ -47,5 +48,22 @@ export class PassengerService {
       LIMIT 3`;
 
     return drivers.map((driver) => new Driver(driver));
+  }
+
+  async findInvoicesByPassengerId(passengerId: number): Promise<Invoice[]> {
+    const invoices = await this.databaseService.connection<Passenger[]>`
+      SELECT
+        "i"."id",
+        "i"."price",
+        "i"."created_at"
+      FROM "invoices" "i"
+      INNER JOIN "rides" "r"
+      ON "i"."ride_id" = "r"."id"
+      INNER JOIN "passengers" "p"
+      ON "r"."passenger_id" = "p"."id"
+      WHERE "r"."passenger_id" = ${passengerId}
+    `;
+
+    return invoices.map((invoice) => new Invoice(invoice));
   }
 }

--- a/src/ride/dto/patch-ride.dto.ts
+++ b/src/ride/dto/patch-ride.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsIn } from 'class-validator';
+
+export class PatchRideDTO {
+  @IsIn([true])
+  @Expose({ name: 'isCompleted' })
+  @ApiProperty({
+    description: 'A boolean representing if the ride has been completed',
+    name: 'isCompleted',
+  })
+  is_completed: true;
+}

--- a/src/ride/dto/update-ride.dto.ts
+++ b/src/ride/dto/update-ride.dto.ts
@@ -1,4 +1,0 @@
-import { Ride } from '../entities/ride.entity';
-import { PickType } from '@nestjs/swagger';
-
-export class UpdateRideDTO extends PickType(Ride, ['is_completed'] as const) {}

--- a/src/ride/entities/ride.entity.ts
+++ b/src/ride/entities/ride.entity.ts
@@ -1,6 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
-import { IsInt, Min } from 'class-validator';
+import {
+  IsBoolean,
+  IsDate,
+  IsInt,
+  IsLatitude,
+  IsLongitude,
+  Min,
+} from 'class-validator';
 
 export class Ride {
   @IsInt()
@@ -8,6 +15,7 @@ export class Ride {
   @ApiProperty({ description: 'The identifier of the resource' })
   id: number;
 
+  @IsLatitude()
   @Expose({ name: 'originLatitude' })
   @ApiProperty({
     description: 'A valid latitude represented as a floating point number',
@@ -16,6 +24,7 @@ export class Ride {
   })
   origin_latitude: string;
 
+  @IsLongitude()
   @Expose({ name: 'originLongitude' })
   @ApiProperty({
     description: 'A valid longitude represented as a floating point number',
@@ -24,6 +33,7 @@ export class Ride {
   })
   origin_longitude: string;
 
+  @IsLatitude()
   @Expose({ name: 'destinationLatitude' })
   @ApiProperty({
     description: 'A valid latitude represented as a floating point number',
@@ -32,6 +42,7 @@ export class Ride {
   })
   destination_latitude: string;
 
+  @IsLongitude()
   @Expose({ name: 'destinationLongitude' })
   @ApiProperty({
     description: 'A valid longitude represented as a floating point number',
@@ -40,6 +51,7 @@ export class Ride {
   })
   destination_longitude: string;
 
+  @IsBoolean()
   @Expose({ name: 'isCompleted' })
   @ApiProperty({
     description: 'A boolean representing if the ride has been completed',
@@ -47,20 +59,32 @@ export class Ride {
   })
   is_completed: boolean;
 
+  @IsInt()
+  @Min(1)
   @Expose({ name: 'driverId' })
   @ApiProperty({
-    description: ' The identifier of the driver associated with this resource',
+    description: 'The identifier of the driver associated with this resource',
     name: 'driverId',
   })
   driver_id: number;
 
+  @IsInt()
+  @Min(1)
   @Expose({ name: 'passengerId' })
   @ApiProperty({
     description:
-      ' The identifier of the passenger associated with this resource',
+      'The identifier of the passenger associated with this resource',
     name: 'passengerId',
   })
   passenger_id: number;
+
+  @IsDate()
+  @Expose({ name: 'createdAt' })
+  @ApiProperty({
+    description: 'A timestamp representing when the resource was created',
+    name: 'createdAt',
+  })
+  created_at: string;
 
   constructor(partial: Partial<Ride>) {
     Object.assign(this, partial);

--- a/src/ride/ride.controller.ts
+++ b/src/ride/ride.controller.ts
@@ -12,15 +12,15 @@ import {
   Controller,
   Get,
   Param,
+  Patch,
   Post,
-  Put,
   Query,
   UseInterceptors,
 } from '@nestjs/common';
 import { CreateRideDTO } from './dto/create-ride.dto';
 import { RideService } from './ride.service';
 import { Ride } from './entities/ride.entity';
-import { UpdateRideDTO } from './dto/update-ride.dto';
+import { PatchRideDTO } from './dto/patch-ride.dto';
 
 @ApiTags('rides')
 @Controller('rides')
@@ -42,7 +42,7 @@ export class RideController {
     return await this.rideService.create(createRideDTO);
   }
 
-  @Put(':id')
+  @Patch(':id')
   @ApiOperation({
     requestBody: { $ref: 'UpdateRideDTO' },
     summary: 'Update a ride',
@@ -52,11 +52,11 @@ export class RideController {
     type: Ride,
   })
   @ApiBadRequestResponse({ description: 'Request is invalid.' })
-  async update(
+  async patch(
     @Param('id') id: number,
-    @Body() updateRideDTO: UpdateRideDTO,
+    @Body() updateRideDTO: PatchRideDTO,
   ): Promise<Ride> {
-    return this.rideService.update(id, updateRideDTO);
+    return this.rideService.patch(id, updateRideDTO);
   }
 
   @Get()

--- a/src/ride/ride.service.ts
+++ b/src/ride/ride.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { CreateRideDTO } from './dto/create-ride.dto';
 import { DatabaseService } from '../database/database.service';
 import { Ride } from './entities/ride.entity';
-import { UpdateRideDTO } from './dto/update-ride.dto';
+import { PatchRideDTO } from './dto/patch-ride.dto';
 
 @Injectable()
 export class RideService {
@@ -39,7 +39,8 @@ export class RideService {
         "destination_longitude",
         "driver_id",
         "passenger_id",
-        "is_completed"
+        "is_completed",
+        "created_at"
       FROM "rides"
       WHERE "id" = ${id}
     `;
@@ -47,7 +48,7 @@ export class RideService {
     return new Ride(createdRide);
   }
 
-  async update(id: number, updateRideDTO: UpdateRideDTO): Promise<Ride> {
+  async patch(id: number, updateRideDTO: PatchRideDTO): Promise<Ride> {
     await this.databaseService.connection<Ride[]>`
       UPDATE "rides" SET
       "is_completed" = ${updateRideDTO.is_completed}
@@ -63,7 +64,8 @@ export class RideService {
         "destination_longitude",
         "driver_id",
         "passenger_id",
-        "is_completed"
+        "is_completed",
+        "created_at"
       FROM "rides"
       WHERE "id" = ${id}
     `;
@@ -81,7 +83,8 @@ export class RideService {
         "destination_longitude",
         "driver_id",
         "passenger_id",
-        "is_completed"
+        "is_completed",
+        "created_at"
       FROM "rides"
       WHERE "is_completed" = ${active}
     `;
@@ -99,7 +102,8 @@ export class RideService {
         "destination_longitude",
         "driver_id",
         "passenger_id",
-        "is_completed"
+        "is_completed",
+        "created_at"
       FROM "rides"
     `;
 


### PR DESCRIPTION
This PR adds an `invoices` table, and seed data, and it exposes the resources via the endpoint `GET /passengers/:id/invoices`. It also changes the endpoint `PUT /rides` to `PATCH /rides` to be more complaint with RESTful.