### PR TITLE
Add error responses to endpoints

### DIFF
--- a/src/driver/driver.controller.ts
+++ b/src/driver/driver.controller.ts
@@ -9,12 +9,14 @@ import {
   ClassSerializerInterceptor,
   Controller,
   Get,
+  NotFoundException,
   Param,
   Query,
   UseInterceptors,
 } from '@nestjs/common';
 import { Driver } from './entities/driver.entity';
 import { DriverService } from './driver.service';
+import { NotFoundResponse } from 'src/exception/dto/not-found-response.dto';
 
 @ApiTags('drivers')
 @Controller('drivers')
@@ -65,9 +67,13 @@ export class DriverController {
   @ApiOkResponse({ description: 'Request has been successful.', type: Driver })
   @ApiNotFoundResponse({
     description: 'We could not find a driver with the specified id.',
+    type: NotFoundResponse,
   })
   async find(@Param('id') id: number): Promise<Driver> {
-    console.log(id);
-    return this.driverService.find(id);
+    try {
+      return await this.driverService.find(id);
+    } catch (error) {
+      throw new NotFoundException(error.message);
+    }
   }
 }

--- a/src/driver/driver.service.ts
+++ b/src/driver/driver.service.ts
@@ -51,12 +51,16 @@ export class DriverService {
   }
 
   async find(id: number): Promise<Driver> {
-    const [result] = await this.databaseService.connection<Driver[]>`
+    const [driver] = await this.databaseService.connection<Driver[]>`
       SELECT "id", "name", "profile_picture"
       FROM "drivers"
       WHERE "id" = ${id}
     `;
 
-    return new Driver(result);
+    if (!driver) {
+      throw new Error('We could not find a driver with the given id.');
+    }
+
+    return new Driver(driver);
   }
 }

--- a/src/driver/entities/driver.entity.ts
+++ b/src/driver/entities/driver.entity.ts
@@ -5,7 +5,7 @@ import { IsInt, IsNotEmpty, IsUrl, Min } from 'class-validator';
 export class Driver {
   @IsInt()
   @Min(1)
-  @ApiProperty({ description: 'The identifier of the resource' })
+  @ApiProperty({ description: 'The identifier of the resource', example: 1 })
   id: number;
 
   @IsNotEmpty()

--- a/src/exception/dto/invalid-request-response.dto.ts
+++ b/src/exception/dto/invalid-request-response.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt } from 'class-validator';
+
+export class InvalidRequestResponse {
+  @ApiProperty({
+    description: 'A short description of what caused the error',
+    example: 'The field example cannot be empty',
+  })
+  message: string;
+
+  @ApiProperty({
+    description: 'The name of the error that occurred',
+    example: 'Bad Request',
+  })
+  error: string;
+
+  @IsInt()
+  @ApiProperty({
+    description: 'A three digit number representing the HTTP status code',
+    example: 400,
+  })
+  statusCode: number;
+}

--- a/src/exception/dto/not-found-response.dto.ts
+++ b/src/exception/dto/not-found-response.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt } from 'class-validator';
+
+export class NotFoundResponse {
+  @ApiProperty({
+    description: 'A short description of what caused the error',
+    example: 'We could not find a resource with the given id',
+  })
+  message: string;
+
+  @ApiProperty({
+    description: 'The name of the error that occurred',
+    example: 'Not found',
+  })
+  error: string;
+
+  @IsInt()
+  @ApiProperty({
+    description: 'A three digit number representing the HTTP status code',
+    example: 404,
+  })
+  statusCode: number;
+}

--- a/src/invoice/entities/invoice.entity.ts
+++ b/src/invoice/entities/invoice.entity.ts
@@ -5,7 +5,7 @@ import { IsDate, IsDecimal, IsInt, MaxLength, Min } from 'class-validator';
 export class Invoice {
   @IsInt()
   @Min(1)
-  @ApiProperty({ description: 'The identifier of the resource' })
+  @ApiProperty({ description: 'The identifier of the resource', example: 1 })
   id: number;
 
   @IsDecimal({ decimal_digits: '2', force_decimal: true })

--- a/src/passenger/entities/passenger.entity.ts
+++ b/src/passenger/entities/passenger.entity.ts
@@ -5,7 +5,7 @@ import { IsInt, IsUrl, Min } from 'class-validator';
 export class Passenger {
   @IsInt()
   @Min(1)
-  @ApiProperty({ description: 'The identifier of the resource' })
+  @ApiProperty({ description: 'The identifier of the resource', example: 1 })
   id: number;
 
   @ApiProperty({

--- a/src/passenger/passenger.controller.ts
+++ b/src/passenger/passenger.controller.ts
@@ -8,6 +8,7 @@ import {
   ClassSerializerInterceptor,
   Controller,
   Get,
+  NotFoundException,
   Param,
   UseInterceptors,
 } from '@nestjs/common';
@@ -15,6 +16,7 @@ import { Driver } from '../driver/entities/driver.entity';
 import { Passenger } from './entities/passenger.entity';
 import { PassengerService } from './passenger.service';
 import { Invoice } from 'src/invoice/entities/invoice.entity';
+import { NotFoundResponse } from 'src/exception/dto/not-found-response.dto';
 
 @ApiTags('passengers')
 @Controller('passengers')
@@ -41,9 +43,14 @@ export class PassengerController {
   })
   @ApiNotFoundResponse({
     description: 'We could not find a passenger with the specified id.',
+    type: NotFoundResponse,
   })
   async find(@Param('id') id: number): Promise<Passenger> {
-    return this.passengerService.find(id);
+    try {
+      return await this.passengerService.find(id);
+    } catch (error) {
+      throw new NotFoundException(error.message);
+    }
   }
 
   @Get(':id/near-drivers')
@@ -57,9 +64,14 @@ export class PassengerController {
   })
   @ApiNotFoundResponse({
     description: 'We could not find a passenger with the specified id.',
+    type: NotFoundResponse,
   })
   async findNearDrivers(@Param('id') id: number): Promise<Driver[]> {
-    return this.passengerService.findNearDriversByPassengerId(id);
+    try {
+      return await this.passengerService.findNearDriversByPassengerId(id);
+    } catch (error) {
+      throw new NotFoundException(error.message);
+    }
   }
 
   @Get(':id/invoices')
@@ -69,7 +81,15 @@ export class PassengerController {
     isArray: true,
     type: Invoice,
   })
+  @ApiNotFoundResponse({
+    description: 'We could not find a passenger with the specified id.',
+    type: NotFoundResponse,
+  })
   async findInvoicesByPassengerId(@Param('id') id: number): Promise<Invoice[]> {
-    return this.passengerService.findInvoicesByPassengerId(id);
+    try {
+      return await this.passengerService.findInvoicesByPassengerId(id);
+    } catch (error) {
+      throw new NotFoundException(error.message);
+    }
   }
 }

--- a/src/ride/dto/patch-ride.dto.ts
+++ b/src/ride/dto/patch-ride.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
-import { IsIn } from 'class-validator';
+import { Equals } from 'class-validator';
 
 export class PatchRideDTO {
-  @IsIn([true])
+  @Equals(true, { message: () => 'isCompleted must be equal to true' })
   @Expose({ name: 'isCompleted' })
   @ApiProperty({
     description: 'A boolean representing if the ride has been completed',

--- a/src/ride/entities/ride.entity.ts
+++ b/src/ride/entities/ride.entity.ts
@@ -12,7 +12,7 @@ import {
 export class Ride {
   @IsInt()
   @Min(1)
-  @ApiProperty({ description: 'The identifier of the resource' })
+  @ApiProperty({ description: 'The identifier of the resource', example: 1 })
   id: number;
 
   @IsLatitude()
@@ -64,6 +64,7 @@ export class Ride {
   @Expose({ name: 'driverId' })
   @ApiProperty({
     description: 'The identifier of the driver associated with this resource',
+    example: 1,
     name: 'driverId',
   })
   driver_id: number;
@@ -74,6 +75,7 @@ export class Ride {
   @ApiProperty({
     description:
       'The identifier of the passenger associated with this resource',
+    example: 1,
     name: 'passengerId',
   })
   passenger_id: number;

--- a/src/ride/ride.controller.ts
+++ b/src/ride/ride.controller.ts
@@ -1,6 +1,7 @@
 import {
   ApiBadRequestResponse,
   ApiCreatedResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiQuery,
@@ -18,9 +19,11 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { CreateRideDTO } from './dto/create-ride.dto';
-import { RideService } from './ride.service';
-import { Ride } from './entities/ride.entity';
+import { InvalidRequestResponse } from 'src/exception/dto/invalid-request-response.dto';
+import { NotFoundResponse } from 'src/exception/dto/not-found-response.dto';
 import { PatchRideDTO } from './dto/patch-ride.dto';
+import { Ride } from './entities/ride.entity';
+import { RideService } from './ride.service';
 
 @ApiTags('rides')
 @Controller('rides')
@@ -51,7 +54,14 @@ export class RideController {
     description: 'Ride has been updated successfully.',
     type: Ride,
   })
-  @ApiBadRequestResponse({ description: 'Request is invalid.' })
+  @ApiBadRequestResponse({
+    description: 'Request is invalid.',
+    type: InvalidRequestResponse,
+  })
+  @ApiNotFoundResponse({
+    description: 'We could not find a ride with the specified id.',
+    type: NotFoundResponse,
+  })
   async patch(
     @Param('id') id: number,
     @Body() updateRideDTO: PatchRideDTO,


### PR DESCRIPTION
This PR introduces error responses for endpoints when applicable.

For example if a user hits the endpoint `GET /drivers/1`, it will receive a response like the following in a best case scenario:

```json
{
  "id": 1,
  "name": "John Doe",
  "profilePicture": "https://example.com/picture.jpeg"
}
```

Or one representing a 404 HTTP status code in case no resource with that id can be found:

```json
{
  "message": "We could not find a resource with the given id",
  "error": "Not found",
  "statusCode": 404
}
```

This behavior is now also documented on Swagger.