### PR TITLE
Add bad request response to GET /drivers/nearby endpoint

### DIFF
--- a/src/driver/driver.controller.ts
+++ b/src/driver/driver.controller.ts
@@ -1,4 +1,5 @@
 import {
+  ApiBadRequestResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -16,6 +17,8 @@ import {
 } from '@nestjs/common';
 import { Driver } from './entities/driver.entity';
 import { DriverService } from './driver.service';
+import { Coordinate } from './dto/coordinate.dto';
+import { InvalidRequestResponse } from '../exception/dto/invalid-request-response.dto';
 import { NotFoundResponse } from '../exception/dto/not-found-response.dto';
 
 @ApiTags('drivers')
@@ -57,11 +60,15 @@ export class DriverController {
     isArray: true,
     type: Driver,
   })
-  async findInRadius(
-    @Query('latitude') latitude: string,
-    @Query('longitude') longitude: string,
-  ): Promise<Driver[]> {
-    return this.driverService.findInRadius(latitude, longitude);
+  @ApiBadRequestResponse({
+    description: 'Request is invalid.',
+    type: InvalidRequestResponse,
+  })
+  async findInRadius(@Query() coordinate: Coordinate): Promise<Driver[]> {
+    return this.driverService.findInRadius(
+      coordinate.latitude,
+      coordinate.longitude,
+    );
   }
 
   @Get(':id')

--- a/src/driver/dto/coordinate.dto.ts
+++ b/src/driver/dto/coordinate.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsLatitude, IsLongitude } from 'class-validator';
+
+export class Coordinate {
+  @IsLatitude()
+  @ApiProperty({
+    description: 'A valid latitude represented as a floating point number',
+    example: '18.4636960171801',
+  })
+  latitude: string;
+
+  @IsLongitude()
+  @ApiProperty({
+    description: 'A valid longitude represented as a floating point number',
+    example: '-69.93474882920843',
+  })
+  longitude: string;
+}

--- a/test/driver.e2e-spec.ts
+++ b/test/driver.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { DriverModule } from '../src/driver/driver.module';
 import { DriverService } from '../src/driver/driver.service';
@@ -17,6 +17,8 @@ describe('DriverController (e2e)', () => {
       .compile();
 
     app = moduleFixture.createNestApplication();
+
+    app.useGlobalPipes(new ValidationPipe());
     await app.init();
   });
 
@@ -107,6 +109,20 @@ describe('DriverController (e2e)', () => {
           profilePicture: 'https://randomuser.me/api/portraits/women/41.jpg',
         },
       ]);
+  });
+
+  it('/drivers/nearby (GET) 400', () => {
+    return request(app.getHttpServer())
+      .get('/drivers/nearby')
+      .expect(400)
+      .expect({
+        message: [
+          'latitude must be a latitude string or number',
+          'longitude must be a longitude string or number',
+        ],
+        error: 'Bad Request',
+        statusCode: 400,
+      });
   });
 
   it('/drivers/1 (GET)', () => {


### PR DESCRIPTION
This PR fixes an oversight that was causing a HTTP 500 status code when `GET /drivers/nearby` was called without the required query parameters `latitude` and `longitude` by returning a HTTP 400 status code and a response object representing the error that occurred.